### PR TITLE
Diagnostics from PC and from build server

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -16,7 +16,7 @@ trait CommonScalaModule extends ScalaModule with ScalafixModule {
     ) ++ super.repositoriesTask()
   }
 
-  def scalaVersion = "3.7.0"
+  def scalaVersion = "3.7.0" // "3.7.2-RC1-bin-SNAPSHOT"
   def scalacOptions = Seq("-no-indent", "-Wunused:all")
 }
 

--- a/build.mill
+++ b/build.mill
@@ -28,6 +28,7 @@ object sls extends CommonScalaModule {
     ivy"com.github.plokhotnyuk.jsoniter-scala:jsoniter-scala-core_2.13:2.35.2".forceVersion(),
     ivy"co.fs2::fs2-io:3.13.0-M2",
     ivy"tech.neander::jsonrpclib-fs2::0.0.8+26-13de833b-SNAPSHOT".forceVersion(),
+    ivy"ch.qos.logback:logback-classic:1.4.14",
     ivy"tech.neander::langoustine-app::0.0.22",
     ivy"com.lihaoyi::os-lib:0.11.4",
     ivy"org.polyvariant.smithy4s-bsp::bsp4s:0.4.1",

--- a/build.mill
+++ b/build.mill
@@ -16,7 +16,7 @@ trait CommonScalaModule extends ScalaModule with ScalafixModule {
     ) ++ super.repositoriesTask()
   }
 
-  def scalaVersion = "3.7.0" // "3.7.2-RC1-bin-SNAPSHOT"
+  def scalaVersion = "3.7.0"
   def scalacOptions = Seq("-no-indent", "-Wunused:all")
 }
 

--- a/sls/resources/logback.xml
+++ b/sls/resources/logback.xml
@@ -28,10 +28,7 @@
     <appender-ref ref="SLS_LOG"/>
   </logger>
 
-  <!-- Root logger (optional) -->
   <root level="INFO">
-    <!-- Add a console appender if desired -->
-    <!-- <appender-ref ref="STDOUT"/> -->
   </root>
 
 </configuration>

--- a/sls/resources/logback.xml
+++ b/sls/resources/logback.xml
@@ -1,0 +1,37 @@
+<configuration>
+
+  <!-- Appender for dotty.tools.pc -->
+  <appender name="PC_LOG" class="ch.qos.logback.core.FileAppender">
+    <file>./.logs/pc.log</file>
+    <append>false</append>
+    <encoder>
+      <pattern>%date %-5level [%thread] %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Appender for org.scala.abusers.pc -->
+  <appender name="SLS_LOG" class="ch.qos.logback.core.FileAppender">
+    <file>./.logs/sls.log</file>
+    <append>false</append>
+    <encoder>
+      <pattern>%date %-5level [%thread] %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Logger for dotty.tools.pc -->
+  <logger name="dotty.tools.pc" level="DEBUG" additivity="false">
+    <appender-ref ref="PC_LOG"/>
+  </logger>
+
+  <!-- Logger for org.scala.abusers.pc -->
+  <logger name="org.scala.abusers" level="DEBUG" additivity="false">
+    <appender-ref ref="SLS_LOG"/>
+  </logger>
+
+  <!-- Root logger (optional) -->
+  <root level="INFO">
+    <!-- Add a console appender if desired -->
+    <!-- <appender-ref ref="STDOUT"/> -->
+  </root>
+
+</configuration>

--- a/sls/src/org/scala/abusers/sls/BspClient.scala
+++ b/sls/src/org/scala/abusers/sls/BspClient.scala
@@ -44,51 +44,35 @@ def makeBspClient(path: String, channel: FS2Channel[IO], report: String => IO[Un
       )
     )
 
-def bspClientHandler(lspClient: Communicate[IO]): List[Endpoint[IO]] = BSPCodecs.serverEndpoints(
-  new BuildClient[IO] {
-    private def notify(msg: String) =
-      lspClient.notification(
-        window.showMessage(
-          langoustine.lsp.structures
-            .ShowMessageParams(`type` = langoustine.lsp.enumerations.MessageType.Info, message = msg)
+def bspClientHandler(lspClient: Communicate[IO], diagnosticManager: DiagnosticManager): List[Endpoint[IO]] =
+  BSPCodecs.serverEndpoints(
+    new BuildClient[IO] {
+      private def notify(msg: String) =
+        lspClient.notification(
+          window.showMessage(
+            langoustine.lsp.structures
+              .ShowMessageParams(`type` = langoustine.lsp.enumerations.MessageType.Info, message = msg)
+          )
         )
-      )
 
-    def onBuildLogMessage(input: LogMessageParams): IO[Unit] = notify(
-      s"handling onBuildLogMessage: $input"
-    )
+      def onBuildLogMessage(input: LogMessageParams): IO[Unit] = IO.unit
 
-    def onBuildPublishDiagnostics(input: PublishDiagnosticsParams): IO[Unit] = notify(
-      s"handling onBuildPublishDiagnostics: $input"
-    )
+      def onBuildPublishDiagnostics(input: PublishDiagnosticsParams): IO[Unit] =
+        notify(s"We've just got $input") >>
+          diagnosticManager.onBuildPublishDiagnostics(lspClient, input)
 
-    def onBuildShowMessage(input: ShowMessageParams): IO[Unit] =
-      notify(
-        s"handling onBuildShowMessage: $input"
-      )
+      def onBuildShowMessage(input: ShowMessageParams): IO[Unit] = IO.unit
 
-    def onBuildTargetDidChange(input: DidChangeBuildTarget): IO[Unit] = notify(
-      s"handling onBuildTargetDidChange: $input"
-    )
+      def onBuildTargetDidChange(input: DidChangeBuildTarget): IO[Unit] = IO.unit
 
-    def onBuildTaskFinish(input: OnBuildTaskFinishInput): IO[Unit] = notify(
-      s"handling onBuildTaskFinish: $input"
-    )
+      def onBuildTaskFinish(input: OnBuildTaskFinishInput): IO[Unit] = IO.unit
 
-    def onBuildTaskProgress(input: TaskProgressParams): IO[Unit] = notify(
-      s"handling onBuildTaskProgress: $input"
-    )
+      def onBuildTaskProgress(input: TaskProgressParams): IO[Unit] = IO.unit
 
-    def onBuildTaskStart(input: OnBuildTaskStartInput): IO[Unit] = notify(
-      s"handling onBuildTaskStart: $input"
-    )
+      def onBuildTaskStart(input: OnBuildTaskStartInput): IO[Unit] = IO.unit
 
-    def onRunPrintStderr(input: PrintParams): IO[Unit] = notify(
-      s"handling onRunPrintStderr: $input"
-    )
+      def onRunPrintStderr(input: PrintParams): IO[Unit] = IO.unit
 
-    def onRunPrintStdout(input: PrintParams): IO[Unit] = notify(
-      s"handling onRunPrintStdout: $input"
-    )
-  }
-)
+      def onRunPrintStdout(input: PrintParams): IO[Unit] = IO.unit
+    }
+  )

--- a/sls/src/org/scala/abusers/sls/BspStateManager.scala
+++ b/sls/src/org/scala/abusers/sls/BspStateManager.scala
@@ -6,12 +6,12 @@ import bsp.BuildTarget.BuildTargetScalaBuildTarget
 import bsp.CompileParams
 import bsp.InverseSourcesParams
 import cats.effect.kernel.Ref
-import cats.effect.std.MapRef
+import cats.effect.std.AtomicCell
 import cats.effect.IO
 import langoustine.lsp.*
 import langoustine.lsp.structures.*
 import org.scala.abusers.pc.ScalaVersion
-import org.scala.abusers.sls.LspNioConverter.asNio
+import org.scala.abusers.sls.NioConverter.asNio
 
 import java.net.URI
 
@@ -34,7 +34,7 @@ object BspStateManager {
   def instance(bspServer: BuildServer): IO[BspStateManager] =
     // We should track this in progress bar. Think of this as `Import Build`
     for {
-      sourcesToTargets <- MapRef.ofScalaConcurrentTrieMap[IO, URI, ScalaBuildTargetInformation]
+      sourcesToTargets <- AtomicCell[IO].of(Map[URI, ScalaBuildTargetInformation]())
       buildTargets     <- Ref.of[IO, Set[ScalaBuildTargetInformation]](Set.empty)
     } yield BspStateManager(bspServer, sourcesToTargets, buildTargets)
 }
@@ -47,24 +47,26 @@ object BspStateManager {
   */
 class BspStateManager(
     val bspServer: BuildServer,
-    sourcesToTargets: MapRef[IO, URI, Option[ScalaBuildTargetInformation]],
+    sourcesToTargets: AtomicCell[IO, Map[URI, ScalaBuildTargetInformation]],
     targets: Ref[IO, Set[ScalaBuildTargetInformation]],
 ) {
   import ScalaBuildTargetInformation.*
 
-  def importBuild =
+  def importBuild(back: Communicate[IO]) =
     for {
+      _ <- LoggingUtils.logMessage(back, "Starting build import.") // in the future this should be a task with progress
       importedBuild <- getBuildInformation(bspServer)
       _ <- bspServer.generic.buildTargetCompile(CompileParams(targets = importedBuild.map(_.buildTarget.id).toList))
       _ <- targets.set(importedBuild)
+      _ <- LoggingUtils.logMessage(back, "Build import finished.")
     } yield ()
 
-  val byScalaVersion: Ordering[ScalaBuildTargetInformation] = new Ordering[ScalaBuildTargetInformation] {
+  private val byScalaVersion: Ordering[ScalaBuildTargetInformation] = new Ordering[ScalaBuildTargetInformation] {
     override def compare(x: ScalaBuildTargetInformation, y: ScalaBuildTargetInformation): Int =
       Ordering[ScalaVersion].compare(x.scalaVersion, y.scalaVersion)
   }
 
-  def getBuildInformation(bspServer: BuildServer): IO[Set[ScalaBuildTargetInformation]] =
+  private def getBuildInformation(bspServer: BuildServer): IO[Set[ScalaBuildTargetInformation]] =
     for {
       workspaceBuildTargets <- bspServer.generic.workspaceBuildTargets()
       scalacOptions <- bspServer.scala.buildTargetScalacOptions(
@@ -75,7 +77,7 @@ class BspStateManager(
       .values
       .toSet
 
-  def buildTargetInverseSources(uri: URI): IO[List[bsp.BuildTargetIdentifier]] =
+  private def buildTargetInverseSources(uri: URI): IO[List[bsp.BuildTargetIdentifier]] =
     for inverseSources <- bspServer.generic
       .buildTargetInverseSources(
         InverseSourcesParams(
@@ -108,19 +110,21 @@ class BspStateManager(
     * We want to fail fast if this is not the case because it is a way bigger problem that we may hide
     */
   def get(uri: URI): IO[ScalaBuildTargetInformation] =
-    sourcesToTargets(uri).get.map(
-      _.getOrElse(throw new IllegalStateException("Get should always be called after didOpen"))
-    )
+    sourcesToTargets.get.map { state =>
+      state.getOrElse(uri, throw new IllegalStateException("Get should always be called after didOpen"))
+    }
 
   def didOpen(in: Invocation[DidOpenTextDocumentParams, IO]): IO[Unit] = {
     val uri = in.params.textDocument.uri.asNio
-    for {
-      possibleIds <- buildTargetInverseSources(uri)
-      targets0    <- targets.get
-      possibleBuildTargets = possibleIds.flatMap(id => targets0.find(_.buildTarget.id == id))
-      bestBuildTarget      = possibleBuildTargets.maxBy(_.buildTarget.project.scala.map(_.data.scalaVersion))
-      _ <- sourcesToTargets(uri).set(Some(bestBuildTarget)) // lets assume we will always update it
-    } yield ()
+    sourcesToTargets.evalUpdate(state =>
+      for {
+        possibleIds <- buildTargetInverseSources(uri)
+        targets0    <- targets.get
+        possibleBuildTargets = possibleIds.flatMap(id => targets0.find(_.buildTarget.id == id))
+        bestBuildTarget      = possibleBuildTargets.maxBy(_.buildTarget.project.scala.map(_.data.scalaVersion))
+        _ <- LoggingUtils.logDebug(in.toClient, s"Best build target for $uri is ${bestBuildTarget.toString}")
+      } yield state.updated(uri, bestBuildTarget)
+    )
   }
 }
 

--- a/sls/src/org/scala/abusers/sls/BspStateManager.scala
+++ b/sls/src/org/scala/abusers/sls/BspStateManager.scala
@@ -12,6 +12,7 @@ import langoustine.lsp.*
 import langoustine.lsp.structures.*
 import org.scala.abusers.pc.ScalaVersion
 import org.scala.abusers.sls.NioConverter.asNio
+import org.scala.abusers.sls.LoggingUtils.*
 
 import java.net.URI
 
@@ -54,11 +55,11 @@ class BspStateManager(
 
   def importBuild(back: Communicate[IO]) =
     for {
-      _ <- LoggingUtils.logMessage(back, "Starting build import.") // in the future this should be a task with progress
+      _ <- back.logMessage("Starting build import.") // in the future this should be a task with progress
       importedBuild <- getBuildInformation(bspServer)
       _ <- bspServer.generic.buildTargetCompile(CompileParams(targets = importedBuild.map(_.buildTarget.id).toList))
       _ <- targets.set(importedBuild)
-      _ <- LoggingUtils.logMessage(back, "Build import finished.")
+      _ <- back.logMessage("Build import finished.")
     } yield ()
 
   private val byScalaVersion: Ordering[ScalaBuildTargetInformation] = new Ordering[ScalaBuildTargetInformation] {
@@ -122,7 +123,7 @@ class BspStateManager(
         targets0    <- targets.get
         possibleBuildTargets = possibleIds.flatMap(id => targets0.find(_.buildTarget.id == id))
         bestBuildTarget      = possibleBuildTargets.maxBy(_.buildTarget.project.scala.map(_.data.scalaVersion))
-        _ <- LoggingUtils.logDebug(in.toClient, s"Best build target for $uri is ${bestBuildTarget.toString}")
+        _ <- in.toClient.logDebug(s"Best build target for $uri is ${bestBuildTarget.toString}")
       } yield state.updated(uri, bestBuildTarget)
     )
   }

--- a/sls/src/org/scala/abusers/sls/Debouncer.scala
+++ b/sls/src/org/scala/abusers/sls/Debouncer.scala
@@ -1,0 +1,26 @@
+package org.scala.abusers.sls
+
+import scala.concurrent.duration.FiniteDuration
+import cats.effect.Temporal
+import cats.effect.Ref
+import cats.effect.kernel.Fiber
+import cats.effect.kernel.Sync
+import cats.effect.IO
+import cats.syntax.all.*
+
+
+class Debouncer(delay: FiniteDuration) {
+
+  private val ref = Ref.unsafe[IO, Option[Fiber[IO, Throwable, Unit]]](None)
+
+  def debounce(run: => IO[Unit]): IO[Unit] =
+    for {
+      fiberOpt <- ref.getAndSet(None)
+      _        <- fiberOpt.traverse_(_.cancel)
+      fiber <- Temporal[IO].start(
+        IO.sleep(delay) *> run
+      )
+      _        <- ref.set(Some(fiber))
+    } yield ()
+
+}

--- a/sls/src/org/scala/abusers/sls/DiagnosticManager.scala
+++ b/sls/src/org/scala/abusers/sls/DiagnosticManager.scala
@@ -1,31 +1,29 @@
 package org.scala.abusers.sls
 
+import bsp.Diagnostic as BspDiagnostic
+import bsp.PublishDiagnosticsParams as BspPublishDiagnosticsParams
 import cats.effect.std.MapRef
 import cats.effect.IO
-import langoustine.lsp.structures.DidChangeTextDocumentParams
-import langoustine.lsp.Invocation
-import langoustine.lsp.structures.PublishDiagnosticsParams as LspPublishDiagnosticsParams
-import langoustine.lsp.structures.Diagnostic as LspDiagnostic
-import langoustine.lsp.requests.textDocument.publishDiagnostics
-import langoustine.lsp
-import langoustine.lsp.runtime.*
-import bsp.PublishDiagnosticsParams as BspPublishDiagnosticsParams
-import bsp.Diagnostic as BspDiagnostic
-import org.scala.abusers.sls.NioConverter.*
 import cats.syntax.all.*
-import java.net.URI
+import langoustine.lsp
+import langoustine.lsp.requests.textDocument.publishDiagnostics
+import langoustine.lsp.runtime.*
+import langoustine.lsp.structures.Diagnostic as LspDiagnostic
+import langoustine.lsp.structures.DidChangeTextDocumentParams
+import langoustine.lsp.structures.PublishDiagnosticsParams as LspPublishDiagnosticsParams
 import langoustine.lsp.Communicate
+import langoustine.lsp.Invocation
+import org.scala.abusers.sls.NioConverter.*
 import smithy4s.json.Json
 
-/**
-  * Diagnostic State Manager
+import java.net.URI
+
+/** Diagnostic State Manager
   *
   * This class is reposnobile for holding the state of the diagnostic displayed on the client
   *
-  * Proposed heuristic is:
-  *   On file save we trigger compilation, and this results in notifications being sent from BSP server.
-  *   We will keep adding diagnostics, and will clean them only when [[PublishDiagnosticsParams.reset]]
-  *   Is
+  * Proposed heuristic is: On file save we trigger compilation, and this results in notifications being sent from BSP
+  * server. We will keep adding diagnostics, and will clean them only when [[PublishDiagnosticsParams.reset]] Is
   *
   * @param publishedDiagnostics
   */
@@ -35,14 +33,17 @@ class DiagnosticManager(publishedDiagnostics: MapRef[IO, URI, Option[Set[LspDiag
     upickle.default.read[LspDiagnostic](data.asByteBuffer)
   }
 
-  def didChange(in: Invocation[DidChangeTextDocumentParams, IO]): IO[Unit] = {
+  def didChange(in: Invocation[DidChangeTextDocumentParams, IO], pcDiags: Vector[LspDiagnostic]): IO[Unit] =
     // remove diagnostic on modified lines
     // ask presentation compiler for diagnostics
-    IO.unit
-  }
+    for {
+      _ <- publishedDiagnostics(in.params.textDocument.uri.asNio).set(pcDiags.toSet.some)
+      request = LspPublishDiagnosticsParams(in.params.textDocument.uri, Opt.empty, pcDiags.toVector)
+      _ <- in.toClient.notification(publishDiagnostics(request))
+    } yield ()
 
   def onBuildPublishDiagnostics(lspClient: Communicate[IO], input: BspPublishDiagnosticsParams): IO[Unit] = {
-    val bspUri = input.textDocument.uri
+    val bspUri   = input.textDocument.uri
     val lspDiags = input.diagnostics.toSet.map(convertDiagnostic)
     def request(diags: Set[LspDiagnostic]) =
       LspPublishDiagnosticsParams(DocumentUri(bspUri.value), Opt.empty, diags.toVector)
@@ -55,14 +56,13 @@ class DiagnosticManager(publishedDiagnostics: MapRef[IO, URI, Option[Set[LspDiag
     } else {
       for {
         currentDiags <- publishedDiagnostics(bspUri.asNio).updateAndGet(_.foldLeft(lspDiags)(_ ++ _).some)
-        _ <- lspClient.notification(publishDiagnostics(request(currentDiags.get)))
+        _            <- lspClient.notification(publishDiagnostics(request(currentDiags.get)))
       } yield ()
     }
   }
 }
 
 object DiagnosticManager {
-  def instance: IO[DiagnosticManager] = {
+  def instance: IO[DiagnosticManager] =
     MapRef.ofScalaConcurrentTrieMap[IO, URI, Set[LspDiagnostic]].map(DiagnosticManager.apply)
-  }
 }

--- a/sls/src/org/scala/abusers/sls/DiagnosticManager.scala
+++ b/sls/src/org/scala/abusers/sls/DiagnosticManager.scala
@@ -23,7 +23,8 @@ import java.net.URI
   * This class is reposnobile for holding the state of the diagnostic displayed on the client
   *
   * Proposed heuristic is: On file save we trigger compilation, and this results in notifications being sent from BSP
-  * server. We will keep adding diagnostics, and will clean them only when [[PublishDiagnosticsParams.reset]] Is
+  * server. We will keep adding diagnostics, and will clean them only when [[PublishDiagnosticsParams.reset]] is
+  * set to true.
   *
   * @param publishedDiagnostics
   */

--- a/sls/src/org/scala/abusers/sls/DiagnosticManager.scala
+++ b/sls/src/org/scala/abusers/sls/DiagnosticManager.scala
@@ -1,0 +1,68 @@
+package org.scala.abusers.sls
+
+import cats.effect.std.MapRef
+import cats.effect.IO
+import langoustine.lsp.structures.DidChangeTextDocumentParams
+import langoustine.lsp.Invocation
+import langoustine.lsp.structures.PublishDiagnosticsParams as LspPublishDiagnosticsParams
+import langoustine.lsp.structures.Diagnostic as LspDiagnostic
+import langoustine.lsp.requests.textDocument.publishDiagnostics
+import langoustine.lsp
+import langoustine.lsp.runtime.*
+import bsp.PublishDiagnosticsParams as BspPublishDiagnosticsParams
+import bsp.Diagnostic as BspDiagnostic
+import org.scala.abusers.sls.NioConverter.*
+import cats.syntax.all.*
+import java.net.URI
+import langoustine.lsp.Communicate
+import smithy4s.json.Json
+
+/**
+  * Diagnostic State Manager
+  *
+  * This class is reposnobile for holding the state of the diagnostic displayed on the client
+  *
+  * Proposed heuristic is:
+  *   On file save we trigger compilation, and this results in notifications being sent from BSP server.
+  *   We will keep adding diagnostics, and will clean them only when [[PublishDiagnosticsParams.reset]]
+  *   Is
+  *
+  * @param publishedDiagnostics
+  */
+class DiagnosticManager(publishedDiagnostics: MapRef[IO, URI, Option[Set[LspDiagnostic]]]) {
+  private def convertDiagnostic(bspDiag: BspDiagnostic): LspDiagnostic = {
+    val data = Json.writeBlob(bspDiag)
+    upickle.default.read[LspDiagnostic](data.asByteBuffer)
+  }
+
+  def didChange(in: Invocation[DidChangeTextDocumentParams, IO]): IO[Unit] = {
+    // remove diagnostic on modified lines
+    // ask presentation compiler for diagnostics
+    IO.unit
+  }
+
+  def onBuildPublishDiagnostics(lspClient: Communicate[IO], input: BspPublishDiagnosticsParams): IO[Unit] = {
+    val bspUri = input.textDocument.uri
+    val lspDiags = input.diagnostics.toSet.map(convertDiagnostic)
+    def request(diags: Set[LspDiagnostic]) =
+      LspPublishDiagnosticsParams(DocumentUri(bspUri.value), Opt.empty, diags.toVector)
+    if input.reset then {
+      for {
+        _ <- publishedDiagnostics(input.textDocument.uri.asNio).set(lspDiags.some)
+        _ <- lspClient.notification(publishDiagnostics(request(lspDiags)))
+      } yield ()
+
+    } else {
+      for {
+        currentDiags <- publishedDiagnostics(bspUri.asNio).updateAndGet(_.foldLeft(lspDiags)(_ ++ _).some)
+        _ <- lspClient.notification(publishDiagnostics(request(currentDiags.get)))
+      } yield ()
+    }
+  }
+}
+
+object DiagnosticManager {
+  def instance: IO[DiagnosticManager] = {
+    MapRef.ofScalaConcurrentTrieMap[IO, URI, Set[LspDiagnostic]].map(DiagnosticManager.apply)
+  }
+}

--- a/sls/src/org/scala/abusers/sls/LoggingUtils.scala
+++ b/sls/src/org/scala/abusers/sls/LoggingUtils.scala
@@ -7,21 +7,23 @@ import langoustine.lsp.structures.ShowMessageParams
 import langoustine.lsp.Communicate
 
 object LoggingUtils {
-  def sendMessage(back: Communicate[IO], msg: String): IO[Unit] =
-    back.notification(
-      requests.window.showMessage,
-      ShowMessageParams(enumerations.MessageType.Info, msg),
-    ) *> logMessage(back, msg)
+  extension (back: Communicate[IO]) {
+    def sendMessage(msg: String): IO[Unit] =
+      back.notification(
+        requests.window.showMessage,
+        ShowMessageParams(enumerations.MessageType.Info, msg),
+      ) *> logMessage(msg)
 
-  def logMessage(back: Communicate[IO], message: String): IO[Unit] =
-    back.notification(
-      requests.window.logMessage,
-      LogMessageParams(enumerations.MessageType.Info, message),
-    )
+    def logMessage(message: String): IO[Unit] =
+      back.notification(
+        requests.window.logMessage,
+        LogMessageParams(enumerations.MessageType.Info, message),
+      )
 
-  def logDebug(back: Communicate[IO], message: String): IO[Unit] =
-    back.notification(
-      requests.window.logMessage,
-      LogMessageParams(enumerations.MessageType.Debug, message),
-    )
+    def logDebug(message: String): IO[Unit] =
+      back.notification(
+        requests.window.logMessage,
+        LogMessageParams(enumerations.MessageType.Debug, message),
+      )
+  }
 }

--- a/sls/src/org/scala/abusers/sls/LoggingUtils.scala
+++ b/sls/src/org/scala/abusers/sls/LoggingUtils.scala
@@ -1,11 +1,10 @@
 package org.scala.abusers.sls
 
-import langoustine.lsp.Communicate
 import cats.effect.IO
 import langoustine.lsp.*
-import langoustine.lsp.structures.ShowMessageParams
 import langoustine.lsp.structures.LogMessageParams
-
+import langoustine.lsp.structures.ShowMessageParams
+import langoustine.lsp.Communicate
 
 object LoggingUtils {
   def sendMessage(back: Communicate[IO], msg: String): IO[Unit] =

--- a/sls/src/org/scala/abusers/sls/LoggingUtils.scala
+++ b/sls/src/org/scala/abusers/sls/LoggingUtils.scala
@@ -1,0 +1,28 @@
+package org.scala.abusers.sls
+
+import langoustine.lsp.Communicate
+import cats.effect.IO
+import langoustine.lsp.*
+import langoustine.lsp.structures.ShowMessageParams
+import langoustine.lsp.structures.LogMessageParams
+
+
+object LoggingUtils {
+  def sendMessage(back: Communicate[IO], msg: String): IO[Unit] =
+    back.notification(
+      requests.window.showMessage,
+      ShowMessageParams(enumerations.MessageType.Info, msg),
+    ) *> logMessage(back, msg)
+
+  def logMessage(back: Communicate[IO], message: String): IO[Unit] =
+    back.notification(
+      requests.window.logMessage,
+      LogMessageParams(enumerations.MessageType.Info, message),
+    )
+
+  def logDebug(back: Communicate[IO], message: String): IO[Unit] =
+    back.notification(
+      requests.window.logMessage,
+      LogMessageParams(enumerations.MessageType.Debug, message),
+    )
+}

--- a/sls/src/org/scala/abusers/sls/LspNioConverter.scala
+++ b/sls/src/org/scala/abusers/sls/LspNioConverter.scala
@@ -1,9 +1,0 @@
-package org.scala.abusers.sls
-
-import langoustine.lsp.runtime.DocumentUri
-
-import java.net.URI
-
-object LspNioConverter {
-  extension (documentUri: DocumentUri) def asNio: URI = URI.create(documentUri.value)
-}

--- a/sls/src/org/scala/abusers/sls/NioConverter.scala
+++ b/sls/src/org/scala/abusers/sls/NioConverter.scala
@@ -7,5 +7,5 @@ import scala.annotation.targetName
 
 object NioConverter {
   extension (documentUri: DocumentUri) @targetName("lspAsNio") def asNio: URI = URI.create(documentUri.value)
-  extension (uri: bsp.URI) @targetName("bspAsNio") def asNio: URI = URI.create(uri.value)
+  extension (uri: bsp.URI) @targetName("bspAsNio") def asNio: URI             = URI.create(uri.value)
 }

--- a/sls/src/org/scala/abusers/sls/NioConverter.scala
+++ b/sls/src/org/scala/abusers/sls/NioConverter.scala
@@ -1,0 +1,11 @@
+package org.scala.abusers.sls
+
+import langoustine.lsp.runtime.DocumentUri
+
+import java.net.URI
+import scala.annotation.targetName
+
+object NioConverter {
+  extension (documentUri: DocumentUri) @targetName("lspAsNio") def asNio: URI = URI.create(documentUri.value)
+  extension (uri: bsp.URI) @targetName("bspAsNio") def asNio: URI = URI.create(uri.value)
+}

--- a/sls/src/org/scala/abusers/sls/ServerImpl.scala
+++ b/sls/src/org/scala/abusers/sls/ServerImpl.scala
@@ -15,6 +15,7 @@ import langoustine.lsp.structures.*
 import langoustine.lsp.structures as lngst
 import org.eclipse.lsp4j
 import org.scala.abusers.pc.IOCancelTokens
+import LoggingUtils.*
 import org.scala.abusers.pc.PresentationCompilerDTOInterop.*
 import org.scala.abusers.pc.PresentationCompilerProvider
 import org.scala.abusers.sls.NioConverter.asNio
@@ -32,7 +33,7 @@ import scala.meta.pc.VirtualFileParams
 import org.scala.abusers.pc.ScalaVersion
 
 class ServerImpl(
-    syncManager: SyncManager,
+    stateManager: StateManager,
     pcProvider: PresentationCompilerProvider,
     cancelTokens: IOCancelTokens,
     diagnosticManager: DiagnosticManager,
@@ -76,7 +77,7 @@ class ServerImpl(
 
     cancelTokens.mkCancelToken.use { token0 =>
       for {
-        docState <- syncManager.getDocumentState(uri0)
+        docState <- stateManager.getDocumentState(uri0)
         inalyHintsParams = new InlayHintsParams {
           import docState.*
           def implicitConversions(): Boolean     = true
@@ -104,7 +105,7 @@ class ServerImpl(
     val position = summon[WithPosition[Params]].position(in.params)
     cancelTokens.mkCancelToken.use { token =>
       for {
-        docState <- syncManager.getDocumentState(uri)
+        docState <- stateManager.getDocumentState(uri)
         offsetParams = toOffsetParams(position, docState, token)
         result <- pcParamsRequest(in.params, offsetParams)(thunk)
       } yield result
@@ -116,17 +117,17 @@ class ServerImpl(
   ): IO[Result] = { // TODO Completion on context bound inserts []
     val uri = summon[WithURI[Params]].uri(params)
     for {
-      info   <- syncManager.getBuildTargetInformation(uri)
+      info   <- stateManager.getBuildTargetInformation(uri)
       pc     <- pcProvider.get(info)
       result <- IO.fromCompletableFuture(IO(thunk(pc)(pcParams)))
     } yield result
   }
 
-  def handleDidSave(in: Invocation[DidSaveTextDocumentParams, IO]) = syncManager.didSave(in)
+  def handleDidSave(in: Invocation[DidSaveTextDocumentParams, IO]) = stateManager.didSave(in)
 
-  def handleDidOpen(in: Invocation[DidOpenTextDocumentParams, IO]) = syncManager.didOpen(in)
+  def handleDidOpen(in: Invocation[DidOpenTextDocumentParams, IO]) = stateManager.didOpen(in)
 
-  def handleDidClose(in: Invocation[DidCloseTextDocumentParams, IO]) = syncManager.didClose(in)
+  def handleDidClose(in: Invocation[DidCloseTextDocumentParams, IO]) = stateManager.didClose(in)
 
   val handleDidChange: Invocation[DidChangeTextDocumentParams, IO] => IO[Unit] = {
     val debounce = Debouncer(300.millis)
@@ -143,8 +144,8 @@ class ServerImpl(
     def pcDiagnostics(in: Invocation[DidChangeTextDocumentParams, IO], info: ScalaBuildTargetInformation, uri: URI): IO[Unit] =
       cancelTokens.mkCancelToken.use { token =>
         for {
-          _ <- LoggingUtils.logDebug(in.toClient, "Getting PresentationCompiler diagnostics")
-          textDocument <- syncManager.getDocumentState(uri)
+          _ <- in.toClient.logDebug("Getting PresentationCompiler diagnostics")
+          textDocument <- stateManager.getDocumentState(uri)
           pc           <- pcProvider.get(info)
           params = virtualFileParams(uri, textDocument.content, token)
           diags <- IO.fromCompletableFuture(IO(pc.didChange(params)))
@@ -154,15 +155,15 @@ class ServerImpl(
     }
 
     in => for {
-      _ <- syncManager.didChange(in)
-      _ <- LoggingUtils.logDebug(in.toClient, "Updated DocumentState")
+      _ <- stateManager.didChange(in)
+      _ <- in.toClient.logDebug("Updated DocumentState")
       uri = in.params.textDocument.uri.asNio
-      info         <- syncManager.getBuildTargetInformation(uri)
+      info         <- stateManager.getBuildTargetInformation(uri)
       _ <- if isSupported(info) then debounce.debounce(pcDiagnostics(in, info, uri)) else IO.unit
     } yield ()
   }
 
-  def handleInitialized(in: Invocation[InitializedParams, IO]): IO[Unit] = syncManager.importBuild(in.toClient)
+  def handleInitialized(in: Invocation[InitializedParams, IO]): IO[Unit] = stateManager.importBuild(in.toClient)
 
   def handleInitialize(
       steward: ResourceSupervisor[IO],
@@ -173,10 +174,10 @@ class ServerImpl(
     val rootUri  = in.params.rootUri.toOption.getOrElse(sys.error("what now?"))
     val rootPath = os.Path(java.net.URI.create(rootUri.value).getPath())
     (for {
-      _         <- LoggingUtils.sendMessage(in.toClient, "ready to initialise!")
+      _         <- in.toClient.sendMessage("Ready to initialise!")
       _         <- importMillBsp(rootPath, in.toClient)
       bspClient <- connectWithBloop(in.toClient, steward, diagnosticManager)
-      _         <- LoggingUtils.logMessage(in.toClient, "Connection with bloop estabilished")
+      _         <- in.toClient.logMessage("Connection with bloop estabilished")
       response <- bspClient.generic.buildInitialize(
         InitializeBuildParams(
           displayName = "bloop",
@@ -186,13 +187,13 @@ class ServerImpl(
           capabilities = bsp.BuildClientCapabilities(languageIds = List(bsp.LanguageId("scala"))),
         )
       )
-      _ <- LoggingUtils.logMessage(in.toClient, s"Response from bsp: $response")
+      _ <- in.toClient.logMessage(s"Response from bsp: $response")
       _ <- bspClient.generic.onBuildInitialized()
       _ <- bspClientDeferred.complete(bspClient)
     } yield InitializeResult(
       capabilities = serverCapabilities,
       serverInfo = Opt(InitializeResult.ServerInfo("My first LSP!")),
-    )).guaranteeCase(s => LoggingUtils.logMessage(in.toClient, s"closing initalize with $s"))
+    )).guaranteeCase(s => in.toClient.logMessage(s"closing initalize with $s"))
   }
 
   private def serverCapabilities: ServerCapabilities =
@@ -228,8 +229,8 @@ class ServerImpl(
             .merge(bspSocketProc.stderr)
             .through(text.utf8.decode)
             .through(text.lines)
-            .evalMap(s => LoggingUtils.logMessage(back, s"[bloop] $s"))
-            .onFinalizeCase(c => LoggingUtils.sendMessage(back, s"Bloop process terminated $c"))
+            .evalMap(s => back.logMessage(s"[bloop] $s"))
+            .onFinalizeCase(c => back.sendMessage(s"Bloop process terminated $c"))
             .compile
             .drain
             .background
@@ -242,11 +243,11 @@ class ServerImpl(
 
     val bspClientRes = for {
       socketPath <- bspProcess
-      _ <- Resource.eval(IO.sleep(1.seconds) *> LoggingUtils.logMessage(back, s"Looking for socket at $socketPath"))
+      _ <- Resource.eval(IO.sleep(1.seconds) *> back.logMessage(s"Looking for socket at $socketPath"))
       channel <- FS2Channel
         .resource[IO]()
         .flatMap(_.withEndpoints(bspClientHandler(back, diagnosticManager)))
-      client <- makeBspClient(socketPath.toString, channel, msg => LoggingUtils.logDebug(back, s"reportin raw: $msg"))
+      client <- makeBspClient(socketPath.toString, channel, msg => back.logDebug(s"reporting raw: $msg"))
     } yield client
 
     steward.acquire(bspClientRes)
@@ -267,7 +268,7 @@ class ServerImpl(
           .through(text.lines)
 
         allOutput
-          .evalMap(s => LoggingUtils.logMessage(back, s))
+          .evalMap(back.logMessage)
           .compile
           .drain
       }

--- a/sls/src/org/scala/abusers/sls/SimpleLanguageServer.scala
+++ b/sls/src/org/scala/abusers/sls/SimpleLanguageServer.scala
@@ -42,10 +42,10 @@ object SimpleScalaServer extends LangoustineApp {
       syncManager       <- SyncManager.instance(textDocumentSync, bspStateManager).toResource
       cancelTokens      <- IOCancelTokens.instance
       diagnosticManager <- DiagnosticManager.instance.toResource
-      impl = ServerImpl(syncManager, pcProvider, cancelTokens)
+      impl = ServerImpl(syncManager, pcProvider, cancelTokens, diagnosticManager)
     } yield LSPBuilder
       .create[IO]
-      .handleRequest(initialize)(impl.handleInitialize(steward, bspClientDeferred, diagnosticManager))
+      .handleRequest(initialize)(impl.handleInitialize(steward, bspClientDeferred))
       .handleNotification(textDocument.didOpen)(impl.handleDidOpen)
       .handleNotification(textDocument.didClose)(impl.handleDidClose)
       .handleNotification(textDocument.didChange)(impl.handleDidChange)

--- a/sls/src/org/scala/abusers/sls/SimpleLanguageServer.scala
+++ b/sls/src/org/scala/abusers/sls/SimpleLanguageServer.scala
@@ -39,10 +39,10 @@ object SimpleScalaServer extends LangoustineApp {
       textDocumentSync  <- TextDocumentSyncManager.instance.toResource
       bspClientDeferred <- Deferred[IO, BuildServer].toResource
       bspStateManager   <- BspStateManager.instance(BuildServer.suspend(bspClientDeferred.get)).toResource
-      syncManager       <- SyncManager.instance(textDocumentSync, bspStateManager).toResource
+      stateManager      <- StateManager.instance(textDocumentSync, bspStateManager).toResource
       cancelTokens      <- IOCancelTokens.instance
       diagnosticManager <- DiagnosticManager.instance.toResource
-      impl = ServerImpl(syncManager, pcProvider, cancelTokens, diagnosticManager)
+      impl = ServerImpl(stateManager, pcProvider, cancelTokens, diagnosticManager)
     } yield LSPBuilder
       .create[IO]
       .handleRequest(initialize)(impl.handleInitialize(steward, bspClientDeferred))

--- a/sls/src/org/scala/abusers/sls/StateManager.scala
+++ b/sls/src/org/scala/abusers/sls/StateManager.scala
@@ -10,10 +10,10 @@ import org.scala.abusers.sls.NioConverter.asNio
 
 import java.net.URI
 
-object SyncManager {
+object StateManager {
 
-  def instance(textDocumentSyncManager: TextDocumentSyncManager, bspStateManager: BspStateManager): IO[SyncManager] =
-    Mutex[IO].map(SyncManager(textDocumentSyncManager, bspStateManager, _))
+  def instance(textDocumentSyncManager: TextDocumentSyncManager, bspStateManager: BspStateManager): IO[StateManager] =
+    Mutex[IO].map(StateManager(textDocumentSyncManager, bspStateManager, _))
 
 }
 
@@ -25,7 +25,7 @@ object SyncManager {
   *
   * By unifying this in single manager, we can control what has to be synchronized.
   */
-class SyncManager(
+class StateManager(
     textDocumentSyncManager: TextDocumentSyncManager,
     bspStateManager: BspStateManager,
     mutex: Mutex[IO],

--- a/sls/src/org/scala/abusers/sls/SyncManager.scala
+++ b/sls/src/org/scala/abusers/sls/SyncManager.scala
@@ -1,0 +1,60 @@
+package org.scala.abusers.sls
+
+import langoustine.lsp.Invocation
+import cats.effect.std.Mutex
+import cats.effect.IO
+import langoustine.lsp.structures.*
+import java.net.URI
+import org.scala.abusers.sls.NioConverter.asNio
+import bsp.CompileParams
+import langoustine.lsp.Communicate
+
+object SyncManager {
+
+  def instance(textDocumentSyncManager: TextDocumentSyncManager, bspStateManager: BspStateManager): IO[SyncManager] =
+    Mutex[IO].map(SyncManager(textDocumentSyncManager, bspStateManager, _))
+
+}
+
+class SyncManager(textDocumentSyncManager: TextDocumentSyncManager, bspStateManager: BspStateManager, mutex: Mutex[IO]) {
+  def didOpen(in: Invocation[DidOpenTextDocumentParams, IO]): IO[Unit] =
+    mutex.lock.surround {
+      textDocumentSyncManager.didOpen(in) *> bspStateManager.didOpen(in)
+    }
+
+  def didChange(in: Invocation[DidChangeTextDocumentParams, IO]) =
+    mutex.lock.surround {
+      textDocumentSyncManager.didChange(in)
+    }
+
+  def didClose(in: Invocation[DidCloseTextDocumentParams, IO]): IO[Unit] =
+    mutex.lock.surround {
+      textDocumentSyncManager.didClose(in)
+    }
+
+  def didSave(in: Invocation[DidSaveTextDocumentParams, IO]): IO[Unit] =
+    mutex.lock.surround {
+      for {
+        _ <- textDocumentSyncManager.didSave(in)
+        info <- bspStateManager.get(in.params.textDocument.uri.asNio)
+      } yield info
+    }.flatMap { info =>
+      bspStateManager.bspServer.generic.buildTargetCompile(CompileParams(targets = List(info.buildTarget.id)))
+    }.void
+
+  def getDocumentState(uri: URI): IO[DocumentState] =
+    mutex.lock.surround {
+      textDocumentSyncManager.get(uri)
+    }
+
+  def getBuildTargetInformation(uri: URI): IO[ScalaBuildTargetInformation] =
+    mutex.lock.surround {
+      bspStateManager.get(uri)
+    }
+
+  def importBuild(client: Communicate[IO]): IO[Unit] =
+    mutex.lock.surround {
+      bspStateManager.importBuild(client)
+    }
+
+}

--- a/sls/src/org/scala/abusers/sls/SyncManager.scala
+++ b/sls/src/org/scala/abusers/sls/SyncManager.scala
@@ -1,13 +1,14 @@
 package org.scala.abusers.sls
 
-import langoustine.lsp.Invocation
+import bsp.CompileParams
 import cats.effect.std.Mutex
 import cats.effect.IO
 import langoustine.lsp.structures.*
-import java.net.URI
-import org.scala.abusers.sls.NioConverter.asNio
-import bsp.CompileParams
 import langoustine.lsp.Communicate
+import langoustine.lsp.Invocation
+import org.scala.abusers.sls.NioConverter.asNio
+
+import java.net.URI
 
 object SyncManager {
 
@@ -16,7 +17,19 @@ object SyncManager {
 
 }
 
-class SyncManager(textDocumentSyncManager: TextDocumentSyncManager, bspStateManager: BspStateManager, mutex: Mutex[IO]) {
+/** Class created to synchronize all access to the state of bsp / textDocument Original problem was that by separating
+  * both of them, didOpen was called in sequence which I believe could end up by some other request stealing the lock.
+  *
+  * Before we didn't synchronize the state modification, and inlayHint request was sent instantly and it accessed
+  * [[bspStateManager.get]] that was not yet completed ([[ MapRef ]] does not lock on get)
+  *
+  * By unifying this in single manager, we can control what has to be synchronized.
+  */
+class SyncManager(
+    textDocumentSyncManager: TextDocumentSyncManager,
+    bspStateManager: BspStateManager,
+    mutex: Mutex[IO],
+) {
   def didOpen(in: Invocation[DidOpenTextDocumentParams, IO]): IO[Unit] =
     mutex.lock.surround {
       textDocumentSyncManager.didOpen(in) *> bspStateManager.didOpen(in)
@@ -33,14 +46,17 @@ class SyncManager(textDocumentSyncManager: TextDocumentSyncManager, bspStateMana
     }
 
   def didSave(in: Invocation[DidSaveTextDocumentParams, IO]): IO[Unit] =
-    mutex.lock.surround {
-      for {
-        _ <- textDocumentSyncManager.didSave(in)
-        info <- bspStateManager.get(in.params.textDocument.uri.asNio)
-      } yield info
-    }.flatMap { info =>
-      bspStateManager.bspServer.generic.buildTargetCompile(CompileParams(targets = List(info.buildTarget.id)))
-    }.void
+    mutex.lock
+      .surround {
+        for {
+          _    <- textDocumentSyncManager.didSave(in)
+          info <- bspStateManager.get(in.params.textDocument.uri.asNio)
+        } yield info
+      }
+      .flatMap { info =>
+        bspStateManager.bspServer.generic.buildTargetCompile(CompileParams(targets = List(info.buildTarget.id)))
+      }
+      .void
 
   def getDocumentState(uri: URI): IO[DocumentState] =
     mutex.lock.surround {

--- a/sls/src/org/scala/abusers/sls/TextDocumentStateManager.scala
+++ b/sls/src/org/scala/abusers/sls/TextDocumentStateManager.scala
@@ -1,7 +1,6 @@
-package org.scala.abusers.sls // TODO package completions are still here when they should not, also we should get whole package completion out of the box
+package org.scala.abusers.sls // TODO also we should get whole package completion out of the box
 
 import cats.effect.*
-import cats.effect.std.MapRef
 import cats.parse.LocationMap
 import cats.syntax.all.*
 import langoustine.lsp.aliases.TextDocumentContentChangeEvent
@@ -9,6 +8,7 @@ import langoustine.lsp.structures.*
 import langoustine.lsp.Invocation
 
 import java.net.URI
+import cats.effect.std.AtomicCell
 
 case class DocumentState(content: String, uri: URI) {
   private lazy val locationMap = LocationMap(content)
@@ -36,13 +36,13 @@ case class DocumentState(content: String, uri: URI) {
   }
 }
 
-object DocumentSyncManager {
-  def instance: IO[DocumentSyncManager] =
-    MapRef.ofScalaConcurrentTrieMap[IO, URI, DocumentState].map(DocumentSyncManager.apply)
+object TextDocumentSyncManager {
+  def instance: IO[TextDocumentSyncManager] =
+    AtomicCell[IO].of(Map[URI, DocumentState]()).map(TextDocumentSyncManager(_))
 }
 
-class DocumentSyncManager(val documents: MapRef[IO, URI, Option[DocumentState]]) {
-  import LspNioConverter.*
+class TextDocumentSyncManager(val documents: AtomicCell[IO, Map[URI, DocumentState]]) {
+  import NioConverter.*
 
   def didOpen(in: Invocation[DidOpenTextDocumentParams, IO]): IO[Unit] =
     getOrCreateDocument(in.params.textDocument.uri.asNio, in.params.textDocument.text.some).void
@@ -51,27 +51,28 @@ class DocumentSyncManager(val documents: MapRef[IO, URI, Option[DocumentState]])
     onTextEditReceived(in.params.textDocument.uri.asNio, in.params.contentChanges)
 
   def didClose(in: Invocation[DidCloseTextDocumentParams, IO]): IO[Unit] =
-    documents.unsetKey(in.params.textDocument.uri.asNio)
+    documents.update(_.removed(in.params.textDocument.uri.asNio))
 
   def didSave(in: Invocation[DidSaveTextDocumentParams, IO]): IO[Unit] =
     getOrCreateDocument(in.params.textDocument.uri.asNio, in.params.text.toOption).void
 
   private def onTextEditReceived(uri: URI, edits: Vector[TextDocumentContentChangeEvent]): IO[Unit] =
     for {
-      _ <- getOrCreateDocument(uri, None)
-      _ <- documents.updateKeyValueIfSet(uri, _.processEdits(edits))
+      doc <- getOrCreateDocument(uri, None)
+      _ <- documents.update(_.updated(uri, doc.processEdits(edits)))
     } yield ()
 
   def get(uri: URI): IO[DocumentState] =
-    documents(uri).get.flatMap(IO.fromOption(_)(IllegalStateException()))
+    documents.get.map(_.get(uri)).flatMap(IO.fromOption(_)(IllegalStateException()))
 
   private def getOrCreateDocument(uri: URI, content: Option[String]): IO[DocumentState] = {
-    val content0 = content.getOrElse("")
-    documents(uri)
-      .updateAndGet {
-        case Some(existing) => Some(existing)
-        case None           => Some(new DocumentState(content0, uri))
+    documents.modify { access =>
+      access.get(uri) match {
+        case Some(doc) => access -> doc
+        case None      =>
+          val newDoc = new DocumentState(content.getOrElse(""), uri)
+          access.updated(uri, newDoc) -> newDoc
       }
-      .map(_.get)
+    }
   }
 }

--- a/sls/src/org/scala/abusers/sls/pc/PresentationCompilerDTOInterop.scala
+++ b/sls/src/org/scala/abusers/sls/pc/PresentationCompilerDTOInterop.scala
@@ -5,7 +5,7 @@ import langoustine.lsp.structures.HoverParams
 import langoustine.lsp.structures.Position
 import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
 import org.scala.abusers.sls.DocumentState
-import org.scala.abusers.sls.LspNioConverter.asNio
+import org.scala.abusers.sls.NioConverter.asNio
 import upickle.default.*
 
 import java.net.URI

--- a/sls/test/src/org/scala/abusers/sls/DocumentSyncTests.scala
+++ b/sls/test/src/org/scala/abusers/sls/DocumentSyncTests.scala
@@ -3,7 +3,7 @@ package org.scala.abusers.sls
 import langoustine.lsp.aliases.*
 import langoustine.lsp.runtime.*
 import langoustine.lsp.structures.*
-import org.scala.abusers.sls.LspNioConverter.asNio
+import org.scala.abusers.sls.NioConverter.asNio
 import weaver.SimpleIOSuite
 
 object TextDocumentSyncSuite extends SimpleIOSuite {
@@ -33,7 +33,7 @@ object TextDocumentSyncSuite extends SimpleIOSuite {
   loggedTest("applies full document change") { log =>
     val uri    = DocumentUri("/home/Test.scala")
     val client = TestClient(log)
-    for mgr <- DocumentSyncManager.instance
+    for mgr <- TextDocumentSyncManager.instance
     _       <- mgr.didOpen(client.input(open(uri, "Hello!")))
 
     _ <- mgr.didChange(
@@ -59,7 +59,7 @@ object TextDocumentSyncSuite extends SimpleIOSuite {
   loggedTest("applies incremental document change at the beggining") { log =>
     val uri    = DocumentUri("/home/Test.scala")
     val client = TestClient(log)
-    for mgr <- DocumentSyncManager.instance
+    for mgr <- TextDocumentSyncManager.instance
     _       <- mgr.didOpen(client.input(open(uri, "val z = 3")))
 
     _ <- mgr.didChange(
@@ -81,7 +81,7 @@ object TextDocumentSyncSuite extends SimpleIOSuite {
   loggedTest("applies incremental document change at the end") { log =>
     val uri    = DocumentUri("/home/Test.scala")
     val client = TestClient(log)
-    for mgr <- DocumentSyncManager.instance
+    for mgr <- TextDocumentSyncManager.instance
     _       <- mgr.didOpen(client.input(open(uri, "val x = 1\nval y = 2")))
 
     // full document replacement
@@ -102,7 +102,7 @@ object TextDocumentSyncSuite extends SimpleIOSuite {
   loggedTest("applies incremental document change with multi line change") { log =>
     val uri    = DocumentUri("/home/Test.scala")
     val client = TestClient(log)
-    for mgr <- DocumentSyncManager.instance
+    for mgr <- TextDocumentSyncManager.instance
     _       <- mgr.didOpen(client.input(open(uri, "val x = 1\nval y = 2\nval z = 3")))
 
     // full document replacement
@@ -124,7 +124,7 @@ object TextDocumentSyncSuite extends SimpleIOSuite {
   loggedTest("applies incremental document change with selection") { log =>
     val uri    = DocumentUri("/home/Test.scala")
     val client = TestClient(log)
-    for mgr <- DocumentSyncManager.instance
+    for mgr <- TextDocumentSyncManager.instance
     _       <- mgr.didOpen(client.input(open(uri, "val x = 1\nval y = 2\nval z = 3")))
 
     // full document replacement


### PR DESCRIPTION
Cancellation is not working, as is my new CompilerTaskQueue in dotty

Right now when you press a letter all diagnostics will dissapear from buffer. This is not intended, we should filter version < than version that introduced diagnostics in presentation compiler. That PR is not ready though
